### PR TITLE
Add simple tests for get_next_weekday

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,14 @@ You can view the full list of configurations in `tradingagents/default_config.py
 
 We welcome contributions from the community! Whether it's fixing a bug, improving documentation, or suggesting a new feature, your input helps make this project better. If you are interested in this line of research, please consider joining our open-source financial AI research community [Tauric Research](https://tauric.ai/).
 
+### Running Tests
+
+After installing the package dependencies, you can run the unit tests with:
+
+```bash
+pytest
+```
+
 ## Citation
 
 Please reference our work if you find *TradingAgents* provides you with some help :)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+import os
+import sys
+import types
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, PROJECT_ROOT)
+
+# Create lightweight package stubs to avoid importing heavy modules
+if 'tradingagents' not in sys.modules:
+    pkg = types.ModuleType('tradingagents')
+    pkg.__path__ = [os.path.join(PROJECT_ROOT, 'tradingagents')]
+    sys.modules['tradingagents'] = pkg
+
+if 'tradingagents.dataflows' not in sys.modules:
+    subpkg = types.ModuleType('tradingagents.dataflows')
+    subpkg.__path__ = [os.path.join(PROJECT_ROOT, 'tradingagents', 'dataflows')]
+    sys.modules['tradingagents.dataflows'] = subpkg

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+
+from tradingagents.dataflows.utils import get_next_weekday
+
+
+def test_get_next_weekday_saturday_to_monday():
+    result = get_next_weekday('2024-04-06')
+    assert result == datetime(2024, 4, 8)
+
+
+def test_get_next_weekday_weekday_unchanged():
+    result = get_next_weekday('2024-04-09')
+    assert result == datetime(2024, 4, 9)


### PR DESCRIPTION
## Summary
- add unit tests covering `get_next_weekday`
- provide minimal pytest config to load modules without heavy dependencies
- document how to run tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ff0f8303c83288e3d706b62bb24fb