### PR TITLE
Add portfolio model and CI workflow

### DIFF
--- a/.github/workflows/portfolio.yml
+++ b/.github/workflows/portfolio.yml
@@ -1,0 +1,26 @@
+name: Portfolio Tests
+
+on:
+  push:
+    paths:
+      - 'tradingagents/**'
+      - 'tests/**'
+      - '.github/workflows/portfolio.yml'
+  pull_request:
+
+jobs:
+  portfolio:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run portfolio tests
+        run: pytest -q tests/test_portfolio.py

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+from tradingagents.portfolio import Portfolio, portfolio_performance
+
+
+def test_basic_portfolio_operations():
+    p = Portfolio(cash=1000)
+    p.deposit(500, datetime(2024, 1, 1))
+    assert p.cash == 1500
+    p.buy("AAPL", 5, 10, datetime(2024, 1, 2))
+    assert p.cash == 1450
+    assert p.positions["AAPL"].quantity == 5
+    p.sell("AAPL", 2, 12, datetime(2024, 1, 3))
+    assert p.cash == 1450 + 24
+    assert p.positions["AAPL"].quantity == 3
+    total = p.total_value({"AAPL": 12})
+    assert total == p.cash + 3 * 12
+
+
+def test_portfolio_performance():
+    p = Portfolio(cash=0)
+    p.deposit(1000, datetime(2024, 1, 1))
+    p.buy("AAPL", 10, 100, datetime(2024, 1, 2))
+    ret, risk = portfolio_performance(p, {"AAPL": [100, 110]})
+    assert abs(ret - 0.1) < 1e-6
+    assert risk == 0.0

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -264,3 +264,14 @@ class TradingAgentsGraph:
     def process_signal(self, full_signal):
         """Process a signal to extract the core decision."""
         return self.signal_processor.process_signal(full_signal)
+
+    def propagate_portfolio(self, tickers: List[str], trade_date: str):
+        """Run the graph for multiple tickers and return decisions."""
+        results = {}
+        for ticker in tickers:
+            final_state, signal = self.propagate(ticker, trade_date)
+            results[ticker] = {
+                "state": final_state,
+                "signal": signal,
+            }
+        return results

--- a/tradingagents/portfolio.py
+++ b/tradingagents/portfolio.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, List, Iterable, Tuple
+
+
+@dataclass
+class Transaction:
+    date: datetime
+    symbol: str
+    quantity: float
+    price: float
+    type: str  # BUY, SELL, DEPOSIT, WITHDRAW
+
+
+@dataclass
+class Position:
+    symbol: str
+    quantity: float
+    average_price: float
+
+
+@dataclass
+class Portfolio:
+    cash: float = 0.0
+    positions: Dict[str, Position] = field(default_factory=dict)
+    history: List[Transaction] = field(default_factory=list)
+
+    def deposit(self, amount: float, date: datetime) -> None:
+        self.cash += amount
+        self.history.append(Transaction(date, "", amount, 0.0, "DEPOSIT"))
+
+    def withdraw(self, amount: float, date: datetime) -> None:
+        if amount > self.cash:
+            raise ValueError("Insufficient cash")
+        self.cash -= amount
+        self.history.append(Transaction(date, "", -amount, 0.0, "WITHDRAW"))
+
+    def buy(self, symbol: str, quantity: float, price: float, date: datetime) -> None:
+        total = quantity * price
+        if total > self.cash:
+            raise ValueError("Insufficient cash to buy")
+        self.cash -= total
+        pos = self.positions.get(symbol)
+        if pos:
+            new_qty = pos.quantity + quantity
+            pos.average_price = (pos.average_price * pos.quantity + price * quantity) / new_qty
+            pos.quantity = new_qty
+        else:
+            self.positions[symbol] = Position(symbol, quantity, price)
+        self.history.append(Transaction(date, symbol, quantity, price, "BUY"))
+
+    def sell(self, symbol: str, quantity: float, price: float, date: datetime) -> None:
+        pos = self.positions.get(symbol)
+        if not pos or pos.quantity < quantity:
+            raise ValueError("Insufficient shares to sell")
+        pos.quantity -= quantity
+        self.cash += quantity * price
+        if pos.quantity == 0:
+            del self.positions[symbol]
+        self.history.append(Transaction(date, symbol, -quantity, price, "SELL"))
+
+    def total_value(self, prices: Dict[str, float]) -> float:
+        value = self.cash
+        for sym, pos in self.positions.items():
+            value += pos.quantity * prices.get(sym, pos.average_price)
+        return value
+
+
+def portfolio_performance(portfolio: Portfolio, price_histories: Dict[str, Iterable[float]]) -> Tuple[float, float]:
+    """Return estimated (return, risk) for the portfolio.
+
+    price_histories maps symbols to a sequence of prices where the first and last
+    elements represent the evaluation window.
+    """
+    weights: Dict[str, float] = {}
+    total = portfolio.cash
+    for sym, pos in portfolio.positions.items():
+        last_price = price_histories.get(sym, [pos.average_price])[-1]
+        w = pos.quantity * last_price
+        weights[sym] = w
+        total += w
+
+    if total == 0:
+        return 0.0, 0.0
+
+    returns: Dict[str, float] = {}
+    for sym, hist in price_histories.items():
+        if len(hist) >= 2:
+            returns[sym] = (hist[-1] - hist[0]) / hist[0]
+
+    weighted_return = 0.0
+    for sym, w in weights.items():
+        if sym in returns:
+            weighted_return += (w / total) * returns[sym]
+
+    mean = weighted_return
+    variance = 0.0
+    for sym, w in weights.items():
+        if sym in returns:
+            variance += (w / total) * (returns[sym] - mean) ** 2
+
+    risk = variance ** 0.5
+    return weighted_return, risk


### PR DESCRIPTION
## Summary
- add portfolio management utilities
- extend trading graph with multi-ticker propagation
- test portfolio operations and performance
- add workflow to run portfolio tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870cce55fa08328bcf049f5ad012b51